### PR TITLE
Optimize 15-34% by hoisting indexing to induce loop unrolling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,12 +113,10 @@ where
         board[x][y] = Mine;
 
         for i in x - 1..=x + 1 {
-            for j in y - 1..=y + 1 {
-                // SAFETY: (x, y) are in 1..=N, 1..=M, so i, j are in bounds
-                unsafe {
-                    if *board.get_unchecked(i).get_unchecked(j) != Mine {
-                        *board.get_unchecked_mut(i).get_unchecked_mut(j) = Closed;
-                    }
+            let chunk = unsafe { board.get_unchecked_mut(i).get_unchecked_mut(y - 1..=y + 1) };
+            for entry in chunk {
+                if *entry != Mine {
+                    *entry = Closed;
                 }
             }
         }


### PR DESCRIPTION
Ran the benchmarks, looked at the annotated assembly in `perf report`. There was pretty clearly no loop unrolling, which is quite a shame because you set this up so that the inner loop had a static trip count.

You can put the unchecked indexing back in if you want, but with this change I get very mixed feedback from the benchmarks on the effect of putting it back:
```
Beginner                time:   [5.2169 ms 5.2204 ms 5.2238 ms]
                        change: [+5.1545% +5.2441% +5.3299%] (p = 0.00 < 0.05)
                        Performance has regressed.

Intermediate            time:   [7.8152 ms 7.8188 ms 7.8225 ms]
                        change: [-4.0490% -3.9902% -3.9351%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Advanced                time:   [7.4161 ms 7.4179 ms 7.4197 ms]
                        change: [+3.4523% +3.4854% +3.5193%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

Hard to understand why removing checks would make something slower, but alternatively there's no measurable gain from adding them so hard to justify adding `unsafe` when there's no data to say it's even helping :shrug: 
But at the same time, edits allowed by maintainers. Go nuts.